### PR TITLE
Make param required only for certain steps, make creds optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           curl https://cdn.deislabs.io/porter/latest/install-linux.sh | bash
           export PATH=$PATH:~/.porter
           porter mixin install kustomize -v 0.2-beta-3-0e19ca4 --url https://github.com/donmstewart/porter-kustomize/releases/download
-          porter mixin install qliksense -v v0.9.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download
+          porter mixin install qliksense -v v0.10.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download
           porter build -v
           # porter publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           curl https://cdn.deislabs.io/porter/latest/install-linux.sh | bash
           export PATH=$PATH:~/.porter
           porter mixin install kustomize -v 0.2-beta-3-0e19ca4 --url https://github.com/donmstewart/porter-kustomize/releases/download
-          porter mixin install qliksense -v v0.10.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download
+          porter mixin install qliksense -v v0.11.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download
           porter build -v
           # porter publish
 

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -33,13 +33,6 @@ RUN helm fetch qlik-edge/qliksense-init --version $QLIKSENSE_INIT_VERSION --unta
 # CI job will update this version and make a PR
 ARG QSEOK_VERSION=1.22.36
 
-# The Qlik docker registry to use for Image layers
-ARG QLIK_REGISTRY=qlik-docker-qsefe.bintray.io
-
-# Air Gapped operation, images are copied to invocation image (this one)
-# to enable images to be pushed to private docker registry
-ARG AIR_GAPPED=false
-
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # Use the BUNDLE_DIR build argument to copy files into the bundle
 ARG BUNDLE_DIR

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Install Porter from here: https://porter.sh/install/
 - Install the followiung Mixins:
   - `porter mixin install kustomize -v 0.2-beta-3-0e19ca4 --url https://github.com/donmstewart/porter-kustomize/releases/download`
-  - `porter mixin install qliksense -v v0.9.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
+  - `porter mixin install qliksense -v v0.10.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
 - Run Porter build: `porter build -v`
 - Ensure connectivity to the target cluster create a kubeconfig credential `porter cred generate`
   - Select `specific value` at the prompt and specify the value. 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Install Porter from here: https://porter.sh/install/
 - Install the followiung Mixins:
   - `porter mixin install kustomize -v 0.2-beta-3-0e19ca4 --url https://github.com/donmstewart/porter-kustomize/releases/download`
-  - `porter mixin install qliksense -v v0.10.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
+  - `porter mixin install qliksense -v v0.11.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
 - Run Porter build: `porter build -v`
 - Ensure connectivity to the target cluster create a kubeconfig credential `porter cred generate`
   - Select `specific value` at the prompt and specify the value. 

--- a/porter.yaml
+++ b/porter.yaml
@@ -43,6 +43,13 @@ parameters:
     description: "Which namespace the qliksense will be installed"
     type: string
     default: ""
+  - name: dockerRegistry
+    description: "Push images/use specified docker registry"
+    type: string
+    default: ""
+    applyTo:
+      - install
+      - upgrade
 
 outputs:
 - name: LoadBalancer
@@ -67,6 +74,7 @@ install:
       description: "Installing: Creating patch based on CR"
       name: qliksense-operator
       cr:
+        dockerRegistry: "{{ bundle.parameters.dockerRegistry }}"
         manifestsRoot: "/cnab/app"
         configs:
         - dataKey: acceptEULA
@@ -114,6 +122,7 @@ upgrade:
       name: qliksense-operator
       cr:
         manifestsRoot: "/cnab/app"
+        dockerRegistry: "{{ bundle.parameters.dockerRegistry }}"
         configs:
         - dataKey: acceptEULA
           values:

--- a/porter.yaml
+++ b/porter.yaml
@@ -49,6 +49,16 @@ outputs:
   - install
   - upgrade
 
+customActions:
+  about:
+    description: "About Qlik Sense"
+    stateless: true
+    modifies: false
+
+about:
+  - qliksense:
+      description: "Use bundled version by default"
+      version: "bundled"
 install:
   - qliksense:
       description: "Installing: Creating patch based on CR"

--- a/porter.yaml
+++ b/porter.yaml
@@ -13,14 +13,15 @@ mixins:
   - exec
 
 
-# See https://porter.sh/wiring/#credentials
-credentials:
+parameters:
   - name: kubeconfig
+    type: file
     path: /root/.kube/config
     description: "The .kubeconfig file to connect to k8s cluster"
-    required: false
-
-parameters:
+    applyTo:
+    - install
+    - upgrade
+    - uninstall
   - name: acceptEULA
     type: string
     description: "User has to accept End User License Aggrement's term to install Qliksense"

--- a/porter.yaml
+++ b/porter.yaml
@@ -18,12 +18,15 @@ credentials:
   - name: kubeconfig
     path: /root/.kube/config
     description: "The .kubeconfig file to connect to k8s cluster"
+    required: false
 
 parameters:
   - name: acceptEULA
     type: string
     description: "User has to accept End User License Aggrement's term to install Qliksense"
-    reqired: true
+    applyTo:
+    - install
+    - upgrade
   - name: profile
     type: string
     description: "Select a profile i.e docker-desktop, aws-eks, gke, azure. default is docker-desktop"


### PR DESCRIPTION
There does not seem to be an applyTo for credentials in CNAB spec?
If we don't make them optional, every action will require cluster credentials, even those who don't need it (and is a pain to deal with from CLI). 
Perhaps we can just deal with it in the install/upgrade action of the mixin? (CHeck the connection as part of preflight? We may need to do this anyway.)