### PR TITLE
Temporary use optional kubeconfig cred

### DIFF
--- a/porter.yaml
+++ b/porter.yaml
@@ -1,8 +1,8 @@
 name: Qliksense
-version: 0.3.0
+version: 0.4.0
 description: "Qliksense application cnab bundle"
-invocationImage: qlik/qliksense-cnab-invocation:v0.3.0
-tag: qlik/qliksense-cnab-bundle:v0.3.0
+invocationImage: qlik/qliksense-cnab-invocation:v0.4.0
+tag: qlik/qliksense-cnab-bundle:v0.4.0
 
 dockerfile: Dockerfile.tmpl
 

--- a/porter.yaml
+++ b/porter.yaml
@@ -12,16 +12,13 @@ mixins:
   - kubernetes
   - exec
 
-
-parameters:
+credentials:
   - name: kubeconfig
-    type: file
     path: /root/.kube/config
     description: "The .kubeconfig file to connect to k8s cluster"
-    applyTo:
-    - install
-    - upgrade
-    - uninstall
+    required: false
+
+parameters:
   - name: acceptEULA
     type: string
     description: "User has to accept End User License Aggrement's term to install Qliksense"
@@ -51,7 +48,7 @@ parameters:
     applyTo:
       - install
       - upgrade
-
+    
 outputs:
 - name: LoadBalancer
   description: "Ingress LoadBalancer hostname"


### PR DESCRIPTION
Though preferable, using kubeconfig as a path param is currently broken in a few ways for porter/cnab. Will revert to using a credential until its fixed and then we can go back to parameters.
Signed-off-by: Boris Kuschel <bkuschel@users.noreply.github.com>