### PR TITLE
Adding preflight checks into Qliksense..

### DIFF
--- a/clustertests/preflight_check/preflight_checks.yaml
+++ b/clustertests/preflight_check/preflight_checks.yaml
@@ -1,0 +1,52 @@
+apiVersion: troubleshoot.replicated.com/v1beta1
+kind: Preflight
+metadata:
+  name: cluster-preflight-checks
+  namespace: PREFLIGHT_NAMESPACE
+spec:
+  collectors:
+    - run: 
+        collectorName: spin-up-pod
+        args: ["-z", "-v", "-w 1", "qnginx001", "80"]
+        command: ["nc"]
+        image: subfuzion/netcat:latest
+        imagePullPolicy: IfNotPresent
+        name: spin-up-pod-check-dns
+        namespace: PREFLIGHT_NAMESPACE
+        timeout: 30s
+
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "<= 1.13.0"
+              message: The application requires at Kubernetes 1.13.0 or later, and recommends 1.15.0.
+              uri: https://www.kubernetes.io
+          - warn:
+              when: "< 1.13.1"
+              message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.15.0 or later.
+              uri: https://kubernetes.io
+          - pass:
+              when: ">= 1.13.0"
+              message: Good to go.
+    - deploymentStatus:
+        checkName: check for deploymentStatus
+        name: qnginx001
+        namespace: PREFLIGHT_NAMESPACE
+        outcomes:
+          - fail:
+              when: "= 0"
+              message: deployment not found
+          - pass:
+              when: "> 0"
+              message: deployment found
+    - textAnalyze:
+        checkName: DNS check
+        collectorName: spin-up-pod-check-dns
+        fileName: spin-up-pod.txt
+        regex: succeeded
+        outcomes:
+          - fail:
+              message: DNS check failed
+          - pass:
+              message: DNS check passed

--- a/porter.yaml
+++ b/porter.yaml
@@ -62,11 +62,21 @@ customActions:
     description: "About Qlik Sense"
     stateless: true
     modifies: false
+  preflight:
+    description: "Run preflight checks"
+    stateless: true
+    modifies: false
 
 about:
   - qliksense:
       description: "Use bundled version by default"
       version: "bundled"
+preflight:
+  - exec:
+      description: "Running preflight checks.."
+      command: bash
+      flags:
+        c: /cnab/app/preflight.sh -n {{ bundle.parameters.namespace }}
 install:
   - qliksense:
       description: "Installing: Creating patch based on CR"

--- a/porter.yaml
+++ b/porter.yaml
@@ -1,5 +1,5 @@
 name: Qliksense
-version: 0.4.0
+version: 0.5.0
 description: "Qliksense application cnab bundle"
 invocationImage: qlik/qliksense-cnab-invocation:v0.4.0
 tag: qlik/qliksense-cnab-bundle:v0.4.0

--- a/preflight.sh
+++ b/preflight.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# test deployment and service name we will use to test
+appName="qnginx001"
+continue_install=false;
+namespace=""
+unset preflight_status
+
+print_help() {
+    echo "usage: ./preflight.sh [OPTIONS]
+   Options:
+   -h          Prints help.
+   -n string   namespace to use.
+   "
+}
+
+# accept value for namespace in case we run this script from CLI
+while getopts "n:h" opt; do
+  case $opt in
+    n)
+      namespace=$OPTARG
+      ;;
+    h)
+      print_help
+      exit 1
+      ;;  
+    \?)
+      # in case we want to abort installation in the event of preflight check failure
+      # exit 1 
+      ;;
+  esac
+done
+
+if [[ $namespace == "" ]]; then
+    echo "namespace empty, resetting it to default namespace."
+    namespace="default"
+fi
+
+echo "namespace to use: $namespace"
+# replace value of namespace in preflight_checks.yaml
+sed -i -e "s/PREFLIGHT_NAMESPACE/$namespace/g" clustertests/preflight_check/preflight_checks.yaml
+
+# create a test deployment and service and then run preflight in this setup
+kubectl create deployment $appName --image=nginx -n $namespace && \
+kubectl create service clusterip $appName --tcp=80:80 -n $namespace && \
+kubectl -n $namespace wait --for=condition=ready pod -l app=$appName --timeout=120s && \
+/usr/local/bin/preflight clustertests/preflight_check/preflight_checks.yaml --interactive=false | tee outfile.txt
+
+# optional, will download support_bundle for further inspection.
+# this is of little use now, as this will be downloaded into the container running this script.
+# we intend to address this feature in future.
+echo "Downloading support bundle: "
+/usr/local/bin/support-bundle clustertests/preflight_check/preflight_checks.yaml
+
+# infer status of the preflight checks to determine if we should continue with Qliksense installation or not.
+preflight_status=$( tail -n 2 outfile.txt )
+
+# cleaning up our setup after running checks.
+(kubectl delete deployment $appName -n $namespace) || true
+(kubectl delete service $appName -n $namespace) || true
+rm outfile.txt
+
+# depending on the status of the checks, we will print an appropriate message and continue with installation.
+if [[ "$preflight_status" == *PASS* ]]; then
+    echo "Preflight checks have passed."
+else
+    echo "Preflight checks have failed, please proceed at your own risk..."
+    # For now, we will not abort installation if preflight checks fail.
+    # exit 1
+fi
+
+echo "Installing Qliksense..."


### PR DESCRIPTION
This PR contains:

- Support to include namespace as part of the kubernetes mixin in porter.yaml
- Support to perform preflight checks using troubleshoot

**Please Note:** This will not abort qliksense install if preflight checks fail. It will print a message saying preflight checks failed and continue the install.