### PR TITLE
Passing profile to the about custom action

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Thje lao
 - Install Porter from here: https://porter.sh/install/
 - Install the followiung Mixins:
   - `porter mixin install kustomize -v 0.2-beta-3-0e19ca4 --url https://github.com/donmstewart/porter-kustomize/releases/download`
-  - `porter mixin install qliksense -v v0.14.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
+  - `porter mixin install qliksense -v v0.15.0 --url https://github.com/qlik-oss/porter-qliksense/releases/download`
 - Run Porter build: `porter build -v`
 - Ensure connectivity to the target cluster create a kubeconfig credential `porter cred generate`
   - Select `specific value` at the prompt and specify the value. 

--- a/porter.yaml
+++ b/porter.yaml
@@ -83,6 +83,7 @@ about:
   - qliksense:
       description: "Use bundled version by default"
       version: "bundled"
+      profile: "manifests/{{ bundle.parameters.profile }}"
 preflight:
   - exec:
       description: "Running preflight checks.."


### PR DESCRIPTION
Expected failure:
```
MacBook-Pro:qliksense-k8s dlx$ porter invoke --action about --param profile=boo
invoking custom action about on Qliksense...
executing about action from Qliksense (bundle instance: Qliksense)
Use bundled version by default
2020/01/13 23:11:24 error executing kustomize, error: exit status 1
Error: exit status 1
executing kustomize process failed with error: exit status 1, stderr: Error: evalsymlink failure on 'manifests/boo' : lstat /cnab/app/manifests/boo: no such file or directory

err: exit status 1
Error: mixin execution failed: exit status 1
Error: 1 error occurred:
        * failed to invoke the bundle: container exit code: 1, message: <nil>. fetching outputs failed: error copying outputs from container: Error: No such container:path: 2661a6218d669c42ae9b5ff492cc24840b6aecb9ad97d2b3d57e61afdec3bda1:/cnab/app/outputs

```
Expected success:
```
MacBook-Pro:qliksense-k8s dlx$ porter invoke --action about --param profile=base
invoking custom action about on Qliksense...
executing about action from Qliksense (bundle instance: Qliksense)
Use bundled version by default
qlikSenseVersion: 1.21.23
images:
- alpine
- docker.io/bitnami/redis:4.0.12
- qlik-docker-qsefe.bintray.io/audit:1.15.3
- qlik-docker-qsefe.bintray.io/chronos-worker:0.5.10
- qlik-docker-qsefe.bintray.io/chronos:0.9.15
- qlik-docker-qsefe.bintray.io/collections:1.0.94
- qlik-docker-qsefe.bintray.io/data-connector-odbc:6.35.0
- qlik-docker-qsefe.bintray.io/data-connector-qwc:0.69.0
- qlik-docker-qsefe.bintray.io/data-connector-rest:2.21.0
- qlik-docker-qsefe.bintray.io/data-prep-service:2.160.0
- qlik-docker-qsefe.bintray.io/data-rest-source:1.0.4
- qlik-docker-qsefe.bintray.io/dcaas-web:1.1.57
- qlik-docker-qsefe.bintray.io/dcaas:1.6.27
- qlik-docker-qsefe.bintray.io/edge-auth:2.59.0
- qlik-docker-qsefe.bintray.io/encryption:3.1.11
- qlik-docker-qsefe.bintray.io/engine-qv:12.521.0
- qlik-docker-qsefe.bintray.io/engine:12.521.0
- qlik-docker-qsefe.bintray.io/eventing:0.0.11
- qlik-docker-qsefe.bintray.io/feature-flags:1.2.2
- qlik-docker-qsefe.bintray.io/generic-links:0.15.0
- qlik-docker-qsefe.bintray.io/geo-operations-service:1.1.0
- qlik-docker-qsefe.bintray.io/groups:1.2.0
- qlik-docker-qsefe.bintray.io/hub:1.0.123
- qlik-docker-qsefe.bintray.io/identity-providers:0.2.0
- qlik-docker-qsefe.bintray.io/insights:2.0.1
- qlik-docker-qsefe.bintray.io/keys:1.0.4
- qlik-docker-qsefe.bintray.io/leader-elector:1.3
- qlik-docker-qsefe.bintray.io/licenses:2.10.0
- qlik-docker-qsefe.bintray.io/locale:1.0.5
- qlik-docker-qsefe.bintray.io/management-console:2.211.0
- qlik-docker-qsefe.bintray.io/nats-streaming:0.14.2
- qlik-docker-qsefe.bintray.io/nginx-ingress-controller:1.4.9
- qlik-docker-qsefe.bintray.io/nl-broker:1.5.0
- qlik-docker-qsefe.bintray.io/nl-parser:0.36.0
- qlik-docker-qsefe.bintray.io/odag:1.27.0
- qlik-docker-qsefe.bintray.io/policy-decision-service:1.53.1
- qlik-docker-qsefe.bintray.io/precedents:0.70.0
- qlik-docker-qsefe.bintray.io/prometheus-nats-exporter:0.3.0
- qlik-docker-qsefe.bintray.io/qix-data-connection:1.12.19
- qlik-docker-qsefe.bintray.io/qix-data-reload:1.3.5
- qlik-docker-qsefe.bintray.io/qix-datafiles:1.0.11
- qlik-docker-qsefe.bintray.io/qix-sessions:5.0.10
- qlik-docker-qsefe.bintray.io/qlikview-client:12.50.2055
- qlik-docker-qsefe.bintray.io/qnatsd:0.3.1
- qlik-docker-qsefe.bintray.io/quotas:0.7.0
- qlik-docker-qsefe.bintray.io/reload-tasks:0.1.14
- qlik-docker-qsefe.bintray.io/reporting-composer:3.0.1
- qlik-docker-qsefe.bintray.io/reporting-proxy:2.1.0
- qlik-docker-qsefe.bintray.io/reporting-service:5.3.0
- qlik-docker-qsefe.bintray.io/reporting-web-renderer:2.15.0
- qlik-docker-qsefe.bintray.io/resource-library:2.8.0
- qlik-docker-qsefe.bintray.io/sense-client:6.264.0
- qlik-docker-qsefe.bintray.io/simple-oidc-provider:0.2.0
- qlik-docker-qsefe.bintray.io/spaces:1.10.2
- qlik-docker-qsefe.bintray.io/temporary-contents:1.3.3
- qlik-docker-qsefe.bintray.io/tenants:1.4.0
- qlik-docker-qsefe.bintray.io/users:1.14.6

execution completed successfully!
MacBook-Pro:qliksense-k8s dlx$ 

```