### PR TITLE
Update porter version deps yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,5 +1,5 @@
 org.qlik.operator.cli.sense-installer.version.min: v0.5.5
-org.qlik.operator.cli.porter.version.min: v0.22.1-beta.1
+org.qlik.operator.cli.porter.version.min: v0.22.2-beta.1
 org.qlik.operator.mixin.qliksense.version.min: v0.16.0
 org.qlik.qseok.version: v1.21.23
 org.qlik.stream: edge

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,5 +1,5 @@
 org.qlik.operator.cli.sense-installer.version.min: v0.5.5
-org.qlik.operator.cli.porter.version.min: 0.2-beta-3-0e19ca4
+org.qlik.operator.cli.porter.version.min: v0.22.1-beta.1
 org.qlik.operator.mixin.qliksense.version.min: v0.16.0
 org.qlik.qseok.version: v1.21.23
 org.qlik.stream: edge


### PR DESCRIPTION
The porter version:`0.2-beta-3-0e19ca4` does not support custom actions. Hence we are stepping up the minimum porter version to be the latest one to support the same.