### PR TITLE
messaging metrics containers args fix

### DIFF
--- a/manifests/base/resources/messaging/patches/statefulSet-nats-delete-args.yaml
+++ b/manifests/base/resources/messaging/patches/statefulSet-nats-delete-args.yaml
@@ -7,3 +7,5 @@ metadata:
       containers:
       - name: main
         args: null
+      - name: metrics
+        args: null

--- a/manifests/base/resources/messaging/patches/statefulSet-nats.yaml
+++ b/manifests/base/resources/messaging/patches/statefulSet-nats.yaml
@@ -20,3 +20,10 @@ spec:
         - --jwt_users_file=/opt/bitnami/nats/users.json
         - --jwt_auth_url=$(KEYS_URI)/keys/qlik.api.internal
 
+      - name: metrics
+        args:
+        - -connz
+        - -routez
+        - -subz
+        - -varz
+        - "http://localhost:8222"

--- a/manifests/base/resources/messaging/patches/statefulSet-streaming-delete-args.yaml
+++ b/manifests/base/resources/messaging/patches/statefulSet-streaming-delete-args.yaml
@@ -8,3 +8,5 @@ spec:
       containers:
       - name: main
         args: null
+      - name: metrics
+        args: null

--- a/manifests/base/resources/messaging/patches/statefulSet-streaming.yaml
+++ b/manifests/base/resources/messaging/patches/statefulSet-streaming.yaml
@@ -127,3 +127,9 @@ spec:
             configMapKeyRef:
               key: natsStreamingClusterId
               name: messaging-configs
+
+      - name: metrics
+        args:
+          - -channelz
+          - -serverz
+          - "http://localhost:8222"


### PR DESCRIPTION
Related to https://github.com/helm/helm/issues/3470, where a fix was applied to Helm 3, but not Helm 2.

These included patches ensure that the final yaml rendered is the same whether we use helm2 or helm3 templating.