### PR TITLE
Add a better chart cache for air gap

### DIFF
--- a/charts/README.MD
+++ b/charts/README.MD
@@ -1,0 +1,2 @@
+This contains the chart cache directory for the operator that are pulled from public helm chart repositories during manifest generations.
+Charts that are not available publically can also be placed here manually and refered to by a HelmChart Generator.

--- a/transformers/fullpath.yaml
+++ b/transformers/fullpath.yaml
@@ -7,3 +7,5 @@ fieldSpecs:
   path: patches/path
 - kind: SelectivePatch
   path: patches/patches
+- kind: HelmChart
+  path: chartHome

--- a/transformers/kustomization.yaml
+++ b/transformers/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- fullpath.yaml
 - qseokversion.yaml
+- fullpath.yaml
+

--- a/transformers/qseokversion.yaml
+++ b/transformers/qseokversion.yaml
@@ -13,7 +13,7 @@ patches:
     metadata:
       name: helmchart
     releaseNamespace: default
-    tmpChartHome: .chartcache/qliksense
+    chartHome: ../../charts
     chartRepo: https://qlik.bintray.com/edge
     chartName: qliksense
     chartVersion: 1.21.23
@@ -27,7 +27,7 @@ patches:
     metadata:
       name: qliksense-init
     releaseNamespace: default
-    tmpChartHome: .chartcache/qliksense-init
+    chartHome: ../../charts
     chartRepo: https://qlik.bintray.com/edge
     chartName: qliksense-init
     chartVersion: 1.1.0


### PR DESCRIPTION
Issues with air gap mode and using a tmp directory chart cache. Better solution is to use the full path transformer and use a directory in the configuration.

Signed-off-by: Boris Kuschel <boris.kuschel@qlik.com>